### PR TITLE
Fixes invalid ami-id error by using newer linux ami

### DIFF
--- a/terraform-example-basic/main.tf
+++ b/terraform-example-basic/main.tf
@@ -5,8 +5,8 @@ provider "aws" {
 
 # Create an EC2 instance
 resource "aws_instance" "example" {
-  # AMI ID for Amazon Linux AMI 2016.03.0 (HVM)
-  ami           = "ami-08111162"
+  # AMI ID for Amazon Linux 2018.03.0 (HVM)
+  ami           = "ami-0cd3dfa4e37921605"
   instance_type = "t2.micro"
 
   tags {


### PR DESCRIPTION

<img width="786" alt="Screen Shot 2019-05-13 at 9 09 59 AM" src="https://user-images.githubusercontent.com/21035422/57606318-8fb7ac00-7560-11e9-8131-87b52046181e.png">


#### What does this PR do?
- Enables a successful terraform apply operation.

