### PR TITLE
Revert "Fixes invalid ami-id error by using newer linux ami"

### DIFF
--- a/terraform-example-basic/main.tf
+++ b/terraform-example-basic/main.tf
@@ -5,8 +5,8 @@ provider "aws" {
 
 # Create an EC2 instance
 resource "aws_instance" "example" {
-  # AMI ID for Amazon Linux 2018.03.0 (HVM)
-  ami           = "ami-0cd3dfa4e37921605"
+  # AMI ID for Amazon Linux AMI 2016.03.0 (HVM)
+  ami           = "ami-08111162"
   instance_type = "t2.micro"
 
   tags {


### PR DESCRIPTION
Reverts gruntwork-io/infrastructure-as-code-training#5

- Turns out the error I got was due to the fact that I changed the provider's region.