### PR TITLE
Update how we install Node.js

### DIFF
--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:latest
 MAINTAINER Yevgeniy Brikman <jim@gruntwork.io>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -o Acquire::ForceIPv4=true -y curl
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -o Acquire::ForceIPv4=true -y curl
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 RUN npm install -g nodemon

--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:latest
 MAINTAINER Yevgeniy Brikman <jim@gruntwork.io>
 
-RUN apt-get update && apt-get install -o Acquire::ForceIPv4=true -y nodejs npm
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -o Acquire::ForceIPv4=true -y curl
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install -y nodejs
 RUN npm install -g nodemon
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 RUN mkdir -p /usr/src/app
 COPY ./src /usr/src/app


### PR DESCRIPTION
Fixes #17.

The modern way to install Node.js is now here: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions.

Also, add `DEBIAN_FRONTEND=noninteractive` to ensure `apt-get` calls are non-interactive.