### PR TITLE
Minimal TF 0.13 upgrade

### DIFF
--- a/terraform-example-basic/main.tf
+++ b/terraform-example-basic/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 # Configure the AWS Provider
 provider "aws" {
   region = "us-east-2"

--- a/terraform-example-full/main.tf
+++ b/terraform-example-full/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 # Configure the AWS Provider
 provider "aws" {
   region = "us-east-2"

--- a/terraform-example-full/rails-module/main.tf
+++ b/terraform-example-full/rails-module/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
 # Create an EC2 instance
 resource "aws_instance" "example_rails_app" {
   ami             = var.ami

--- a/terraform-example-s3-backend/main.tf
+++ b/terraform-example-s3-backend/main.tf
@@ -1,5 +1,10 @@
-# Configure the Terraform backend
 terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+
+  # Configure the Terraform backend
   backend "s3" {
     # Be sure to change this bucket name and region to match an S3 Bucket you have already created!
     bucket = "gruntwork-iac-training"


### PR DESCRIPTION
All we did was run the `0.13upgrade` command against all the code to check the syntax, and then required version `0.12.26` in all the modules.