### PR TITLE
WIP: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@yorinasub17 @zackproser @rhoboat


### PR DESCRIPTION
This adds the IaC US team engineers to CODEOWNERS and removes others. Addresses https://github.com/gruntwork-io/cloud-chasers/issues/27.